### PR TITLE
A few fixes for efficiency parsing and modifying

### DIFF
--- a/makeRPRequest.py
+++ b/makeRPRequest.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
   request = {
     "pwg":"EXO",
     "member_of_campaign":args.campaign,
-    "mcdb_id":0,
+#    "mcdb_id":0,
     "dataset_name":args.name,
     "total_events":rp_request.total_nevents(),
     "fragment":fragment_str,

--- a/manageRequests.py
+++ b/manageRequests.py
@@ -515,7 +515,8 @@ def modifyRequests(requests, num_requests, doDryRun, useDev, isLHErequest):
             mod_req['generators'] = reqFields.getGen()
         if (reqFields.useCS() or reqFields.useFiltEff()
             or reqFields.useFiltEffErr() or reqFields.useMatchEff()
-            or reqFields.useMatchEffErr()) and mod_req['generator_parameters'] == []:
+            or reqFields.useMatchEffErr()):# and mod_req['generator_parameters'] == []:
+            print "Resetting generator_parameters"
             mod_req['generator_parameters'] = [{'match_efficiency_error': 0.0,
                                                 'match_efficiency': 1.0,
                                                 'filter_efficiency': 1.0,


### PR DESCRIPTION
- testRequests.py wasn't writing the filter efficiency to the results CSV file! Fixed, so now filter efficiencies will be updated on MCM.
- generator_parameters (MCM field where the filter efficiencies are written) is a list of dicts, for some reason. This means multiple dicts can be added to the list, which is nonsense (only the first one is used, as far as I can tell). I changed manageRequests.py to clear the list before adding a new dict, to avoid multiple dicts.